### PR TITLE
Use custom MAVLink message definitions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mavlink/include/mavlink/v1.0"]
 	path = mavlink/include/mavlink/v1.0
-	url = git://github.com/mavlink/c_library.git
+	url = git://github.com/magicc-uavbook/mavlink_c_library.git
 [submodule "NuttX"]
 	path = NuttX
 	url = git://github.com/PX4/NuttX.git

--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -84,7 +84,7 @@ void mavlink_send_uart_bytes(mavlink_channel_t chan, const uint8_t *ch, int leng
 extern mavlink_status_t *mavlink_get_channel_status(uint8_t chan);
 extern mavlink_message_t *mavlink_get_channel_buffer(uint8_t chan);
 
-#include <v1.0/common/mavlink.h>
+#include <v1.0/MAGICC/mavlink.h>
 
 __END_DECLS
 


### PR DESCRIPTION
After pulling these changes you'll have to update the MAVLink submodule reference. This should theoretically possible within your existing local repo, but I can't get it to work. So just clone a new copy of the repo and initialize the submodules as follows:

git submodule init
git submodule update
